### PR TITLE
Fix bug hard to modify double (float) number.

### DIFF
--- a/PropertyWidget/Delegates/Core/PropertyDelegateDouble.cpp
+++ b/PropertyWidget/Delegates/Core/PropertyDelegateDouble.cpp
@@ -36,10 +36,10 @@ void regDoubleDelegates()
                   , "SliderBox");
 }
 
-class QtnPropertyDoubleSpinBoxHandler: public QtnPropertyEditorHandler<QtnPropertyDoubleBase, QDoubleSpinBox>
+class QtnPropertyDoubleSpinBoxHandler: public QtnPropertyEditorHandler<QtnPropertyDoubleBase, CustomeDoubleSpinBox>
 {
 public:
-    QtnPropertyDoubleSpinBoxHandler(QtnPropertyDoubleBase& property, QDoubleSpinBox& editor)
+    QtnPropertyDoubleSpinBoxHandler(QtnPropertyDoubleBase& property, CustomeDoubleSpinBox& editor)
         : QtnPropertyEditorHandlerType(property, editor)
     {
         if (!property.isEditableByUser())
@@ -51,7 +51,7 @@ public:
 
         updateEditor();
 
-        QObject::connect(  &editor, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged)
+        QObject::connect(  &editor, static_cast<void (CustomeDoubleSpinBox::*)(double)>(&CustomeDoubleSpinBox::valueChanged)
                          , this, &QtnPropertyDoubleSpinBoxHandler::onValueChanged);
     }
 
@@ -69,7 +69,7 @@ private:
 
 QWidget* QtnPropertyDelegateDouble::createValueEditorImpl(QWidget* parent, const QRect& rect, QtnInplaceInfo* inplaceInfo)
 {
-    QDoubleSpinBox* spinBox = new QDoubleSpinBox(parent);
+    CustomeDoubleSpinBox* spinBox = new CustomeDoubleSpinBox(parent);
     spinBox->setGeometry(rect);
 
     new QtnPropertyDoubleSpinBoxHandler(owner(), *spinBox);

--- a/PropertyWidget/Delegates/Core/PropertyDelegateFloat.cpp
+++ b/PropertyWidget/Delegates/Core/PropertyDelegateFloat.cpp
@@ -36,10 +36,10 @@ void regFloatDelegates()
                                 , "SliderBox");
 }
 
-class QtnPropertyFloatSpinBoxHandler: public QtnPropertyEditorHandler<QtnPropertyFloatBase, QDoubleSpinBox>
+class QtnPropertyFloatSpinBoxHandler: public QtnPropertyEditorHandler<QtnPropertyFloatBase, CustomeDoubleSpinBox>
 {
 public:
-    QtnPropertyFloatSpinBoxHandler(QtnPropertyFloatBase& property, QDoubleSpinBox& editor)
+    QtnPropertyFloatSpinBoxHandler(QtnPropertyFloatBase& property, CustomeDoubleSpinBox& editor)
         : QtnPropertyEditorHandlerType(property, editor)
     {
         if (!property.isEditableByUser())
@@ -51,7 +51,7 @@ public:
 
         updateEditor();
 
-        QObject::connect(  &editor, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged)
+        QObject::connect(  &editor, static_cast<void (CustomeDoubleSpinBox::*)(double)>(&CustomeDoubleSpinBox::valueChanged)
                          , this, &QtnPropertyFloatSpinBoxHandler::onValueChanged);
     }
 
@@ -69,7 +69,7 @@ private:
 
 QWidget* QtnPropertyDelegateFloat::createValueEditorImpl(QWidget* parent, const QRect& rect, QtnInplaceInfo* inplaceInfo)
 {
-    QDoubleSpinBox *spinBox = new QDoubleSpinBox(parent);
+    CustomeDoubleSpinBox *spinBox = new CustomeDoubleSpinBox(parent);
     spinBox->setGeometry(rect);
 
     new QtnPropertyFloatSpinBoxHandler(owner(), *spinBox);

--- a/PropertyWidget/Delegates/Utils/PropertyDelegateMisc.cpp
+++ b/PropertyWidget/Delegates/Utils/PropertyDelegateMisc.cpp
@@ -390,6 +390,22 @@ bool QtnPropertyDelegateError::createSubItemValueImpl(QtnDrawContext& /*context*
     return true;
 }
 
+CustomeDoubleSpinBox::CustomeDoubleSpinBox(QWidget *parent) :
+    QDoubleSpinBox(parent)
+{
+
+}
+
+QString CustomeDoubleSpinBox::textFromValue(double value) const
+{
+    //Q_D(const QDoubleSpinBox);
+    QString str = locale().toString(value, 'g', 12);
+    if (qAbs(value) >= 1000.0) {
+        str.remove(locale().groupSeparator());
+    }
+    return str;
+}
+
 QtnPropertyDelegate* qtnCreateDelegateError(QtnPropertyBase& owner, QString error)
 {
     return new QtnPropertyDelegateError(owner, error);

--- a/PropertyWidget/Delegates/Utils/PropertyDelegateMisc.h
+++ b/PropertyWidget/Delegates/Utils/PropertyDelegateMisc.h
@@ -19,6 +19,8 @@
 
 #include "../PropertyDelegate.h"
 
+#include <QDoubleSpinBox>
+
 class QTN_PW_EXPORT QtnInplaceInfo
 {
 public:
@@ -148,6 +150,16 @@ protected:
 private:
     QtnPropertyBase& m_owner;
     QString m_error;
+};
+
+class QTN_PW_EXPORT CustomeDoubleSpinBox : public QDoubleSpinBox
+{
+    Q_OBJECT
+public:
+    explicit CustomeDoubleSpinBox(QWidget *parent = 0);
+
+protected:
+    virtual QString textFromValue(double value) const;
 };
 
 QTN_PW_EXPORT QtnPropertyDelegate* qtnCreateDelegateError(QtnPropertyBase& owner, QString error);


### PR DESCRIPTION
When user input a double or float number into double spinbox (or float spinbox), digits decimal always appear -> hard to input.