### PR TITLE
Fix crash with QtnPropertyWidgetPartsNone flag

### DIFF
--- a/PropertyWidget/PropertyWidget.cpp
+++ b/PropertyWidget/PropertyWidget.cpp
@@ -172,14 +172,14 @@ void QtnPropertyWidget::updateParts()
     }
     else
     {
+        m_layout->addWidget(m_propertyView);
+
         if (m_descriptionSplitter)
         {
             delete m_descriptionSplitter;
             m_descriptionSplitter = nullptr;
             m_descriptionPanel = nullptr;
         }
-
-        m_layout->addWidget(m_propertyView);
     }
 }
 


### PR DESCRIPTION
The removal of the splitter prior to changing the view's parent is the cause of the fall