### PR TITLE
QtnPropertyDelegateSlideBox. Remove hardcoded tooltip string. Add too…

### DIFF
--- a/PropertyWidget/Delegates/Utils/PropertyDelegateSliderBox.cpp
+++ b/PropertyWidget/Delegates/Utils/PropertyDelegateSliderBox.cpp
@@ -44,12 +44,13 @@ void QtnPropertyDelegateSlideBox::applyAttributesImpl(const QtnPropertyDelegateA
     qtnGetAttribute(attributes, "drawBorder", m_drawBorder);
     qtnGetAttribute(attributes, "updateByScroll", m_updateByScroll);
     qtnGetAttribute(attributes, "animate", m_animate);
+    qtnGetAttribute(attributes, "toolTip", m_itemToolTip);
 }
 
 bool QtnPropertyDelegateSlideBox::createSubItemValueImpl(QtnDrawContext& context, QtnSubItem& subItemValue)
 {
     subItemValue.trackState();
-    subItemValue.setTextAsTooltip("Drag/Scroll mouse to change value");
+    subItemValue.setTextAsTooltip(m_itemToolTip);
     subItemValue.drawHandler = qtnMemFn(this, &QtnPropertyDelegateSlideBox::draw);
     subItemValue.eventHandler = qtnMemFn(this, &QtnPropertyDelegateSlideBox::event);
 

--- a/PropertyWidget/Delegates/Utils/PropertyDelegateSliderBox.h
+++ b/PropertyWidget/Delegates/Utils/PropertyDelegateSliderBox.h
@@ -47,6 +47,7 @@ protected:
     bool m_drawBorder;
     bool m_updateByScroll;
     bool m_animate;
+    QString m_itemToolTip;
 
 private:
     void updateDragValuePart(int x, const QRect& rect);


### PR DESCRIPTION
…ltip attribute.
Hardcoded displayed string without tr macro is no good for lib. 