### PR TITLE
DelegateGeoCoord + DelegateGeoPoint 

### DIFF
--- a/PropertyWidget/Delegates/GUI/PropertyDelegateButton.cpp
+++ b/PropertyWidget/Delegates/GUI/PropertyDelegateButton.cpp
@@ -36,7 +36,7 @@ void regButtonDelegates(QtnPropertyDelegateFactory &factory)
 QtnPropertyDelegateButton::QtnPropertyDelegateButton(QtnPropertyButton& owner)
     : QtnPropertyDelegateTyped<QtnPropertyButton, QtnPropertyDelegate>(owner)
 {
-    m_title = owner.name();
+    m_title = owner.displayName();
 }
 
 void QtnPropertyDelegateButton::applyAttributesImpl(const QtnPropertyDelegateAttributes& attributes)

--- a/PropertyWidget/Delegates/PropertyDelegateFactory.cpp
+++ b/PropertyWidget/Delegates/PropertyDelegateFactory.cpp
@@ -125,6 +125,8 @@ void regFloatDelegates(QtnPropertyDelegateFactory& factory);
 void regIntDelegates(QtnPropertyDelegateFactory& factory);
 void regQPointDelegates(QtnPropertyDelegateFactory& factory);
 void regQPointFDelegates(QtnPropertyDelegateFactory& factory);
+void regGeoPointDelegates(QtnPropertyDelegateFactory& factory);
+void regGeoCoordDelegates(QtnPropertyDelegateFactory& factory);
 void regQRectDelegates(QtnPropertyDelegateFactory& factory);
 void regQRectFDelegates(QtnPropertyDelegateFactory& factory);
 void regQSizeDelegates(QtnPropertyDelegateFactory& factory);
@@ -151,6 +153,8 @@ public:
         regIntDelegates(*this);
         regQPointDelegates(*this);
         regQPointFDelegates(*this);
+        regGeoPointDelegates(*this);
+        regGeoCoordDelegates(*this);
         regQRectDelegates(*this);
         regQRectFDelegates(*this);
         regQSizeDelegates(*this);

--- a/PropertyWidget/Delegates/Utils/PropertyDelegateGeoCoord.cpp
+++ b/PropertyWidget/Delegates/Utils/PropertyDelegateGeoCoord.cpp
@@ -1,0 +1,138 @@
+#include "PropertyDelegateGeoCoord.h"
+#include "../../../Core/Core/PropertyDouble.h"
+#include "../PropertyDelegateFactory.h"
+#include "../Utils/PropertyEditorHandler.h"
+
+
+#include <QLineEdit>
+
+void regGeoCoordDelegates()
+{
+  QtnPropertyDelegateFactory::staticInstance().registerDelegate(&QtnPropertyDoubleBase::staticMetaObject
+               , &qtnCreateDelegate<QtnPropertyDelegateGeoCoord, QtnPropertyDoubleBase>
+               , "GeoCoord");
+}
+
+void regGeoCoordDelegates(QtnPropertyDelegateFactory &factory)
+{
+  factory.registerDelegate(&QtnPropertyDoubleBase::staticMetaObject
+               , &qtnCreateDelegate<QtnPropertyDelegateGeoCoord, QtnPropertyDoubleBase>
+               , "GeoCoord");
+}
+
+
+QString val2strGeoCoord(const qreal c)
+{
+    QString s;
+    s = c < 0 ? "-" : "";
+    qreal r = qAbs(c);
+    int deg = static_cast<int>(r);
+    r -= deg;
+    r *= 60;
+    int min = static_cast<int>(r);
+    r -= min;
+    r *= 60;
+    int sec = static_cast<int>(r);
+    if (sec == 60){
+        sec = 0;
+        ++min;
+        if (min == 60){
+            min = 0;
+            ++deg;
+        }
+    }
+
+    QString txt = QString("%1 %2° %3\' %4\"").
+            arg(s).
+            arg(deg, 3, 10, QChar('0')).
+            arg(min, 2, 10, QChar('0')).
+            arg(sec, 2, 10, QChar('0'));
+    return txt;
+}
+
+qreal str2valGeoCoord(const QString &strVal)
+{
+    static const QRegExp parserDeg(".*(\\d+)°.*", Qt::CaseInsensitive);
+    static const QRegExp parserMin(".*(\\d+)\'.*", Qt::CaseInsensitive);
+    static const QRegExp parserSec(".*(\\d+\\.?\\d*)\".*", Qt::CaseInsensitive);
+    static const QRegExp parserSign("^(-).*", Qt::CaseInsensitive);
+
+    QString str = strVal;
+    str.remove(" ");
+    qreal val = 0.;
+    if (parserDeg.exactMatch(str)){
+        if (parserDeg.capturedTexts().size() == 2){
+            val += parserDeg.capturedTexts().at(1).toInt();
+        }
+    }
+    if (parserMin.exactMatch(str)){
+        if (parserMin.capturedTexts().size() == 2){
+            val += parserMin.capturedTexts().at(1).toInt() / 60.;
+        }
+    }
+    if (parserSec.exactMatch(str)){
+        if (parserSec.capturedTexts().size() == 2){
+            val += parserSec.capturedTexts().at(1).toDouble() / 60./ 60.;
+        }
+    }
+    if (parserSign.exactMatch(str)){
+        val = -val;
+    }
+    return val;
+}
+
+class QtnPropertyGeoCoordLineEditHandler: public QtnPropertyEditorHandler<QtnPropertyDoubleBase, QLineEdit>
+{
+public:
+    QtnPropertyGeoCoordLineEditHandler(QtnPropertyDoubleBase& property, QLineEdit& editor)
+        : QtnPropertyEditorHandlerType(property, editor)
+    {
+        if (!property.isEditableByUser())
+            editor.setReadOnly(true);
+
+        double propertyValue = static_cast<qreal>(property.value());
+        editor.setInputMask("# 000° 00\' 00\"");
+        editor.setText(val2strGeoCoord(propertyValue));
+
+        QObject::connect(  &editor, static_cast<void (QLineEdit::*)()>(&QLineEdit::editingFinished)
+                         , this, &QtnPropertyGeoCoordLineEditHandler::onValueChanged);
+    }
+
+private:
+    void updateEditor() override
+    {
+        double editorValue = str2valGeoCoord(editor().text());
+        double propertyValue = static_cast<qreal>(property());
+
+        if (!qFuzzyCompare(editorValue, propertyValue))
+            editor().setText(val2strGeoCoord(propertyValue));
+    }
+
+    void onValueChanged()
+    {
+        qreal val = str2valGeoCoord(editor().text());
+        property() = val;
+    }
+};
+
+
+QWidget* QtnPropertyDelegateGeoCoord::createValueEditorImpl(QWidget* parent, const QRect& rect, QtnInplaceInfo* inplaceInfo)
+{
+    QLineEdit* lineEdit = new QLineEdit(parent);
+    lineEdit->setGeometry(rect);
+
+    new QtnPropertyGeoCoordLineEditHandler(owner(), *lineEdit);
+
+    if (inplaceInfo)
+    {
+        lineEdit->selectAll();
+    }
+
+    return lineEdit;
+}
+
+bool QtnPropertyDelegateGeoCoord::propertyValueToStrImpl(QString& strValue) const
+{    
+    strValue = val2strGeoCoord(owner().value());
+    return true;
+}

--- a/PropertyWidget/Delegates/Utils/PropertyDelegateGeoCoord.h
+++ b/PropertyWidget/Delegates/Utils/PropertyDelegateGeoCoord.h
@@ -1,0 +1,39 @@
+/*
+   Copyright (c) 2012-2016 Alex Zhondin <lexxmark.dev@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef PROPERTY_DELEGATE_GEOCOORD_H
+#define PROPERTY_DELEGATE_GEOCOORD_H
+
+#include "../Utils/PropertyDelegateMisc.h"
+
+class QtnPropertyDoubleBase;
+
+class QTN_PW_EXPORT QtnPropertyDelegateGeoCoord: public QtnPropertyDelegateTyped<QtnPropertyDoubleBase>
+{
+    Q_DISABLE_COPY(QtnPropertyDelegateGeoCoord)
+
+public:
+    QtnPropertyDelegateGeoCoord(QtnPropertyDoubleBase& owner)
+        : QtnPropertyDelegateTyped<QtnPropertyDoubleBase>(owner)
+    {
+    }
+
+protected:
+    QWidget* createValueEditorImpl(QWidget* parent, const QRect& rect, QtnInplaceInfo* inplaceInfo = nullptr) override;
+    bool propertyValueToStrImpl(QString& strValue) const override;
+};
+
+#endif // PROPERTY_DELEGATE_GEOCOORD_H

--- a/PropertyWidget/Delegates/Utils/PropertyDelegateGeoPoint.cpp
+++ b/PropertyWidget/Delegates/Utils/PropertyDelegateGeoPoint.cpp
@@ -1,0 +1,76 @@
+/*
+   Copyright (c) 2012-2016 Alex Zhondin <lexxmark.dev@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "PropertyDelegateGeoPoint.h"
+#include "../../../Core/Core/PropertyQPointF.h"
+#include "../PropertyDelegateFactory.h"
+
+void regGeoPointDelegates()
+{
+    QtnPropertyDelegateFactory::staticInstance().registerDelegate(&QtnPropertyQPointFBase::staticMetaObject
+                 , &qtnCreateDelegate<PropertyDelegateGeoPoint, QtnPropertyQPointFBase>
+                 , "GeoPoint");
+}
+
+void regGeoPointDelegates(QtnPropertyDelegateFactory &factory)
+{
+    factory.registerDelegate(&QtnPropertyQPointFBase::staticMetaObject
+                 , &qtnCreateDelegate<PropertyDelegateGeoPoint, QtnPropertyQPointFBase>
+                 , "GeoPoint");
+}
+
+
+PropertyDelegateGeoPoint::PropertyDelegateGeoPoint(QtnPropertyQPointFBase& owner)
+    : QtnPropertyDelegateTypedEx<QtnPropertyQPointFBase>(owner)
+{
+    QtnPropertyDelegateInfo geoDelegate;
+    geoDelegate.name = "GeoCoord";
+    m_longitudeSubProperty = qtnCreateXProperty(0, &owner);
+    m_longitudeSubProperty->setDelegate(geoDelegate);
+    m_longitudeSubProperty->setDisplayName(QObject::tr("Longitude"));
+
+    m_latitudeSubProperty = qtnCreateYProperty(0, &owner);
+    m_latitudeSubProperty->setDelegate(geoDelegate);
+    m_latitudeSubProperty->setDisplayName(QObject::tr("Latitude"));
+    addSubProperty(m_longitudeSubProperty);
+    addSubProperty(m_latitudeSubProperty);
+}
+
+void PropertyDelegateGeoPoint::applyAttributesImpl(const QtnPropertyDelegateAttributes &attributes)
+{
+    QString tmp;
+
+    if (qtnGetAttribute(attributes, "XDisplayName", tmp))
+        m_longitudeSubProperty->setDisplayName(tmp);
+
+    if (qtnGetAttribute(attributes, "YDisplayName", tmp))
+        m_latitudeSubProperty->setDisplayName(tmp);
+}
+
+QWidget* PropertyDelegateGeoPoint::createValueEditorImpl(QWidget* parent, const QRect& rect, QtnInplaceInfo* inplaceInfo)
+{
+    return createValueEditorLineEdit(parent, rect, true, inplaceInfo);
+}
+
+
+QString val2strGeoCoord(const qreal);
+
+bool PropertyDelegateGeoPoint::propertyValueToStrImpl(QString& strValue) const
+{
+    QPointF value = owner().value();
+    strValue = QString("%1 x %2").arg(val2strGeoCoord(value.x())).arg(val2strGeoCoord(value.y()));
+    return true;
+}

--- a/PropertyWidget/Delegates/Utils/PropertyDelegateGeoPoint.h
+++ b/PropertyWidget/Delegates/Utils/PropertyDelegateGeoPoint.h
@@ -1,0 +1,39 @@
+/*
+   Copyright (c) 2012-2016 Alex Zhondin <lexxmark.dev@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef PROPERTY_DELEGATE_GEOPOINT_H
+#define PROPERTY_DELEGATE_GEOPOINT_H
+
+#include "../Utils/PropertyDelegateMisc.h"
+
+class QtnPropertyQPointFBase;
+
+class QTN_PW_EXPORT PropertyDelegateGeoPoint: public QtnPropertyDelegateTypedEx<QtnPropertyQPointFBase>
+{
+    Q_DISABLE_COPY(PropertyDelegateGeoPoint)
+    QtnProperty* m_longitudeSubProperty;
+    QtnProperty* m_latitudeSubProperty;
+
+public:
+    PropertyDelegateGeoPoint(QtnPropertyQPointFBase& owner);
+
+protected:
+    void applyAttributesImpl(const QtnPropertyDelegateAttributes& attributes) override;
+    QWidget* createValueEditorImpl(QWidget* parent, const QRect& rect, QtnInplaceInfo* inplaceInfo = nullptr) override;
+    bool propertyValueToStrImpl(QString& strValue) const override;
+};
+
+#endif // PROPERTY_DELEGATE_GEOPOINT_H

--- a/PropertyWidget/PropertyWidget.pro
+++ b/PropertyWidget/PropertyWidget.pro
@@ -39,7 +39,9 @@ else: SOURCES += PropertyWidget.cpp \
     Delegates/GUI/PropertyDelegateQPen.cpp \
     Delegates/GUI/PropertyDelegateQBrush.cpp \
     Delegates/GUI/PropertyDelegateButton.cpp \
-    Utils/AccessibilityProxy.cpp
+    Utils/AccessibilityProxy.cpp \
+    Delegates/Utils/PropertyDelegateGeoCoord.cpp \
+    Delegates/Utils/PropertyDelegateGeoPoint.cpp
 
 HEADERS += PropertyWidgetAPI.h \
     PropertyWidget.h \
@@ -72,7 +74,10 @@ HEADERS += PropertyWidgetAPI.h \
     Delegates/GUI/PropertyDelegateQBrush.h \
     Delegates/GUI/PropertyDelegateQColor.h \
     Delegates/GUI/PropertyDelegateButton.h \
-    Utils/AccessibilityProxy.h
+    Utils/AccessibilityProxy.h \
+    Delegates/Utils/PropertyDelegateGeoCoord.h \
+    Delegates/Utils/PropertyDelegateGeoPoint.h
 
 LIBS += -L$$BIN_DIR -lQtnPropertyCore
 INCLUDEPATH += $$TOP_SRC_DIR/Core
+

--- a/PropertyWidget/QtnPropertyWidgetUnity.cpp
+++ b/PropertyWidget/QtnPropertyWidgetUnity.cpp
@@ -29,3 +29,5 @@
 #include "Delegates/GUI/PropertyDelegateQPen.cpp"
 #include "Delegates/GUI/PropertyDelegateQBrush.cpp"
 #include "Delegates/GUI/PropertyDelegateButton.cpp"
+#include "Delegates/Utils/PropertyDelegateGeoCoord.cpp"
+#include "Delegates/Utils/PropertyDelegateGeoPoint.cpp"


### PR DESCRIPTION
Added new delegates for double and QPointF properties, which display and edit values in the form `- 012° 34' 56"`. Delegate names are "GeoPoint" and "GeoCoord". GeoPoint delegate also have attributes "XDisplayName" and "YDisplayName".