### PR TITLE
QtnSinglePropertyValueAs helper class

### DIFF
--- a/Demo/AB/PropertyABColor.cpp
+++ b/Demo/AB/PropertyABColor.cpp
@@ -27,3 +27,17 @@ void QtnPropertyABColor::setClickHandler(
 {
 	QObject::connect(this, &QtnPropertyABColor::click, clickHandler);
 }
+
+bool QtnPropertyMyColor::fromActualValue(const ValueTypeStore& actualValue, OldValueType& oldValue) const
+{
+    oldValue = QColor::fromRgb(actualValue.red, actualValue.green, actualValue.blue);
+    return true;
+}
+
+bool QtnPropertyMyColor::toActualValue(ValueTypeStore& actualValue, const OldValueType& oldValue) const
+{
+    actualValue.red = oldValue.red();
+    actualValue.green = oldValue.green();
+    actualValue.blue = oldValue.blue();
+    return true;
+}

--- a/Demo/AB/PropertyABColor.h
+++ b/Demo/AB/PropertyABColor.h
@@ -41,4 +41,29 @@ Q_SIGNALS:
 	void click(const QtnPropertyABColor *property);
 };
 
+struct MyColor
+{
+    int red = 0;
+    int green = 0;
+    int blue = 0;
+};
+
+class QtnPropertyMyColor : public QtnSinglePropertyValueAs<QtnPropertyQColorBase, MyColor>
+{
+    Q_OBJECT
+
+private:
+    QtnPropertyMyColor(const QtnPropertyMyColor &other) Q_DECL_EQ_DELETE;
+
+public:
+    explicit QtnPropertyMyColor(QObject *parent = nullptr)
+        : QtnSinglePropertyValueAs<QtnPropertyQColorBase, MyColor>(parent)
+    {
+    }
+
+protected:
+    bool fromActualValue(const ValueTypeStore& actualValue, OldValueType& oldValue) const override;
+    bool toActualValue(ValueTypeStore& actualValue, const OldValueType& oldValue) const override;
+};
+
 #endif // PROPERTY_AB_COLOR_H

--- a/Demo/Demo.pef
+++ b/Demo/Demo.pef
@@ -26,6 +26,11 @@ enum FLAGS
 
 property_set SamplePS
 {
+	MyColor myColor
+	{
+        description = "Property to hold MyColor values.";
+	}
+	
     Bool BoolProperty
     {
         description = "Property to hold boolean values.";

--- a/Demo/Demo.peg.cpp
+++ b/Demo/Demo.peg.cpp
@@ -216,6 +216,7 @@ void QtnPropertySetSubPropertySetType::connectDelegates()
 
 QtnPropertySetSamplePS::QtnPropertySetSamplePS(QObject* parent)
     : QtnPropertySet(parent)
+    , myColor(*qtnCreateProperty<QtnPropertyMyColor>(this))
     , BoolProperty(*qtnCreateProperty<QtnPropertyBool>(this))
     , ButtonProperty(*qtnCreateProperty<QtnPropertyButton>(this))
     , ButtonLinkProperty(*qtnCreateProperty<QtnPropertyButton>(this))
@@ -272,6 +273,7 @@ QtnPropertySetSamplePS& QtnPropertySetSamplePS::operator=(const QtnPropertySetSa
 {
     Q_UNUSED(other);
 
+    myColor = other.myColor;
     BoolProperty = other.BoolProperty;
     ButtonProperty = other.ButtonProperty;
     ButtonLinkProperty = other.ButtonLinkProperty;
@@ -336,6 +338,11 @@ bool QtnPropertySetSamplePS::copyValuesImpl(QtnPropertySet* propertySetCopyFrom,
     auto theCopyFrom = qobject_cast<QtnPropertySetSamplePS*>(propertySetCopyFrom);
     if (!theCopyFrom)
         return false;
+
+    if (!(theCopyFrom->myColor.state() & ignoreMask))
+    {
+        myColor = theCopyFrom->myColor;
+    }
 
     if (!(theCopyFrom->BoolProperty.state() & ignoreMask))
     {
@@ -545,6 +552,10 @@ void QtnPropertySetSamplePS::init()
     setName(SamplePS_name);
     
     // start children initialization
+    static QString myColor_name = QStringLiteral("myColor");
+    myColor.setName(myColor_name);
+    static QString myColor_description = "Property to hold MyColor values.";
+    myColor.setDescription(myColor_description);
     static QString BoolProperty_name = QStringLiteral("BoolProperty");
     BoolProperty.setName(BoolProperty_name);
     static QString BoolProperty_description = "Property to hold boolean values.";

--- a/Demo/Demo.peg.h
+++ b/Demo/Demo.peg.h
@@ -88,6 +88,7 @@ public:
     QtnPropertySetSamplePS& operator=(const QtnPropertySetSamplePS& other);
     
     // start children declarations
+    QtnPropertyMyColor& myColor;
     QtnPropertyBool& BoolProperty;
     QtnPropertyButton& ButtonProperty;
     QtnPropertyButton& ButtonLinkProperty;

--- a/QtnProperty/Utils/DoubleSpinBox.cpp
+++ b/QtnProperty/Utils/DoubleSpinBox.cpp
@@ -26,6 +26,14 @@ QString QtnDoubleSpinBox::textFromValue(double val) const
 	return valueToText(val, locale(), decimals(), isGroupSeparatorShown());
 }
 
+QValidator::State QtnDoubleSpinBox::validate(QString& text, int& pos) const
+{
+	for (auto& chr : text)
+		if (chr == QLatin1Char('.') || chr == QLatin1Char(','))
+			chr = locale().decimalPoint();
+	return QDoubleSpinBox::validate(text, pos);
+}
+
 QString QtnDoubleSpinBox::valueToText(
 	double value, const QLocale &locale, int decimals, bool groupSeparatorShown)
 {

--- a/QtnProperty/Utils/DoubleSpinBox.h
+++ b/QtnProperty/Utils/DoubleSpinBox.h
@@ -22,9 +22,10 @@ limitations under the License.
 class QTN_IMPORT_EXPORT QtnDoubleSpinBox : public QDoubleSpinBox
 {
 public:
-	explicit QtnDoubleSpinBox(QWidget *parent = 0);
+	explicit QtnDoubleSpinBox(QWidget *parent = nullptr);
 
 	virtual QString textFromValue(double val) const override;
+	virtual QValidator::State validate(QString &text, int &pos) const override;
 
 	static QString valueToText(double value, const QLocale &locale = QLocale(),
 		int decimals = 15, bool groupSeparatorShown = false);


### PR DESCRIPTION
This is example for https://github.com/qtinuum/QtnProperty/issues/51

I have created QtnSinglePropertyValueAs helper class that implements some QtnPropertyXXXBase interface but stores value with distinct type.

It has two conversion functions to override, see QtnPropertyMyColor example class that is compatible to QtnPropertyQColorBase and stores value as handmade MyColor type.